### PR TITLE
Allowing args to be passed to driver.waitFor.

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -269,16 +269,25 @@
 
     var convertArgument = function(arg){
         if(isElementProxy(arg)){
-            return convertFromElementProxy(arg);
+            return $(convertFromElementProxy(arg));
         } else if(Array.isArray(arg)){
+            var containsElement = false;
+
             //Special case arrays for faster looping
             for(var i = 0; i < arg.length; i++){
                 if(isElementProxy(arg[i])){
                     arg[i] = convertFromElementProxy(arg[i]);
+                    containsElement = true;
+                } else {
+                    arg[i] = convertArgument(arg[i]);
                 }
             }
 
-            return arg;
+            if(containsElement){
+                return $(arg);
+            } else {
+                return arg;
+            }
         } else if(typeof arg === 'object'){
             for(var key in arg){
                 arg[key] = convertArgument(arg[key]);

--- a/server/driver.js
+++ b/server/driver.js
@@ -84,12 +84,13 @@ Driver.prototype.setUrl = function(url, callback){
 
 Driver.prototype.waitFor = function(args, callback){
     var self = this;
-    var startTime, func, timeout, exec;
+    var startTime, func, timeout, exec, funcArgs;
     if(typeof args === 'object'){
         func = args.condition;
         startTime = args.startTime || new Date();
         timeout = args.timeoutMS || config.timeoutMS;
         exec = args.exec;
+        funcArgs = args.args;
     } else {
         func = args;
         startTime = new Date();
@@ -109,7 +110,7 @@ Driver.prototype.waitFor = function(args, callback){
         throw new Error('callback is required');
     }
 
-    this.exec({ func: func }, function(err, result){
+    this.exec({ func: func, args: funcArgs }, function(err, result){
         if(err){
             return callback(err);
         }
@@ -119,7 +120,7 @@ Driver.prototype.waitFor = function(args, callback){
         } else {
             if(new Date() - startTime < timeout){
                 setTimeout(function(){
-                    self.waitFor({ condition: func, timeoutMS: timeout, startTime: startTime }, callback);
+                    self.waitFor({ condition: func, timeoutMS: timeout, startTime: startTime, args: funcArgs }, callback);
                 }, config.retryMS);
             } else {
                 return callback(new Error('waitFor condition timed out (' + timeout + '): "' + func.toString()));
@@ -128,7 +129,7 @@ Driver.prototype.waitFor = function(args, callback){
     });
 
     if(exec){
-        this.exec({ func: exec }, function(err){
+        this.exec({ func: exec, args: funcArgs }, function(err){
             if(err){
                 return callback(err); //todo: prevent double callback
             }
@@ -261,6 +262,16 @@ Driver.prototype.findVisibles = function(args, callback){
     }
 
     return this.findVisible(args, callback);
+};
+
+Driver.prototype.$ = function(args, callback){
+    return this.exec({
+        func: function(arg){
+            return $(arg);
+        },
+
+        args: args
+    }, callback);
 };
 
 module.exports = Driver;

--- a/server/element_proxy.js
+++ b/server/element_proxy.js
@@ -1,5 +1,6 @@
 var ElementProxy = function(driver){
     this.driver = driver;
+    this.isElementProxy = true;
 };
 
 ElementProxy.prototype._exec = function(args, callback){
@@ -15,7 +16,7 @@ ElementProxy.prototype._exec = function(args, callback){
     if(args.func === 'click'){
         return this.driver.exec({
             func: function(args){
-                var elements = $(args.elements);
+                var elements = args.elements;
 
                 if(!elements._isActionable()){
                     throw new Error('Element(s) are not actionable. ' + args.func + ' failed.');
@@ -45,7 +46,7 @@ ElementProxy.prototype._exec = function(args, callback){
             func: function(args){
                 var result;
 
-                var elements = $(args.elements);
+                var elements = args.elements;
                 result = elements[args.func].apply(elements, args.funcArgs);
 
                 return result;
@@ -287,6 +288,11 @@ ElementProxy.prototype.data = function(name, value, callback){
 
 ElementProxy.prototype.removeData = function(name, callback){
     return this._exec({ func: 'removeData', args: arguments });
+};
+
+
+ElementProxy.prototype.append = function(content, callback){
+    return this._exec({ func: 'append', args: arguments });
 };
 
 

--- a/tests/test/elements.js
+++ b/tests/test/elements.js
@@ -378,5 +378,14 @@ exports.setup = function(args){
             assert(first);
             assert.equal(first.length, 1);
         });
+
+        tu.it('append', function(){
+            driver.findVisible('body').append('<div class="append-test"></div>');
+
+            var appended = driver.findVisible('.append-test');
+
+            assert(appended);
+            assert.equal(appended.length, 1);
+        });
     });
 };

--- a/tests/test/jquery.js
+++ b/tests/test/jquery.js
@@ -23,5 +23,20 @@ exports.setup = function(args){
 
             assert.equal(test, "verify harness doesn't clobber jquery in the frame");
         });
+
+        tu.it('driver.$ creates an element', function(){
+            var element = driver.$('<div>test</div>').addClass('made-with-driver');
+            var body = driver.findVisible('body');
+            body.append(element);
+
+            var appended = body.findVisible('.made-with-driver');
+
+            assert(appended);
+            assert.equal(appended.length, 1);
+        });
+
+        tu.it('driver.$ converts an element', function(){
+            assert.equal(driver.$(driver.findVisibles('span')[0]).html(), 'asdf');
+        });
     });
 };

--- a/tests/test/waitfor.js
+++ b/tests/test/waitfor.js
@@ -16,8 +16,6 @@ exports.setup = function(args){
         });
 
         tu.it('waits for a div to appear', function(){
-            var flow = asyncblock.getCurrentFlow();
-
             driver.waitFor({
                 condition: function() {
                     return $('div.test-div').length > 0;
@@ -28,9 +26,7 @@ exports.setup = function(args){
                 },
 
                 timeoutMS: 2000
-            }, flow.add('waitFor'));
-
-            flow.wait('waitFor');
+            });
 
             var div = driver.findVisible('div.test-div');
 
@@ -49,6 +45,38 @@ exports.setup = function(args){
 
             assert(result instanceof Error);
             assert.equal(result.message.indexOf('waitFor condition timed out'), 0);
+        });
+
+        tu.it('passes variables to waitFor', function(){
+            var body = driver.findVisible('body');
+            driver.exec({
+                func: function(){
+                    $('body').append($('<div>test</div>').addClass('test-div-1'));
+                },
+
+                args: body
+            });
+
+            var element = driver.findVisible('.test-div-1');
+
+            driver.waitFor({
+                condition: function(element) {
+                    return element.is(':hidden');
+                },
+
+                exec: function(element){
+                    element.hide();
+                },
+
+                timeoutMS: 2000,
+
+                args: element
+            });
+
+            var div = driver.findElement('div.test-div-1:hidden');
+
+            assert(div);
+            assert.equal(div.length, 1);
         });
     });
 };

--- a/tests/web/jquery.html
+++ b/tests/web/jquery.html
@@ -6,6 +6,7 @@
         <script type="text/javascript">
             $._test = "verify harness doesn't clobber jquery in the frame";
         </script>
+        <span>asdf</span>
         <div class="test-div"></div>
     </body>
 </html>

--- a/typescript/browser-harness.d.ts
+++ b/typescript/browser-harness.d.ts
@@ -46,6 +46,8 @@ declare module "browser-harness" {
         findVisibles(selector: string, callback?: (err: Error, elements: ElementProxy) => void): ElementProxy;
         find(selector: string, callback?: (err: Error, elements: ElementProxy) => void): ElementProxy;
 
+        $(content: any, callback?: (err: Error, elements: ElementProxy) => void): ElementProxy;
+
         events: DriverEvents;
     }
 
@@ -115,6 +117,8 @@ declare module "browser-harness" {
         removeData(name: string, callback?: (err: Error, element: ElementProxy) => void) : ElementProxy
 
         filter(selector: any, callback?: (err: Error, element: ElementProxy) => void) : ElementProxy
+
+        append(content: any, callback?: (err: Error, element: ElementProxy) => void) : ElementProxy
     }
 
     export class Browser {


### PR DESCRIPTION
Automatic conversion of passed DOM elements to jQuery variables.
Add driver.$ to allow jQuery to be invoked directly. Can be used for stuff like $('<div>') or $(element)
Add "append" to element proxy.
